### PR TITLE
feat: expose downloaded manifest statically + check if locale is supported according to manifest

### DIFF
--- a/lib/src/crowdin.dart
+++ b/lib/src/crowdin.dart
@@ -141,10 +141,8 @@ class Crowdin {
 
     allLanguages.firstWhere(
         (l) => l.toLanguageTag() == mappedLocale.toLanguageTag(),
-        orElse: () => allLanguages.firstWhere(
-            (l2) => l2.languageCode == mappedLocale.languageCode,
-            orElse: () => throw CrowdinException(
-                'Locale ${locale.toLanguageTag()} is not supported for this Crowdin project.')));
+        orElse: () => throw CrowdinException(
+            'Locale ${locale.toLanguageTag()} is not a target language for this Crowdin project.'));
   }
 
   /// Load translations from Crowdin for a specific locale

--- a/lib/src/crowdin.dart
+++ b/lib/src/crowdin.dart
@@ -149,7 +149,13 @@ class Crowdin {
     Map<String, dynamic>? distribution;
 
     if (manifest != null) {
-      checkManifestForLocale(locale);
+      try {
+        checkManifestForLocale(locale);
+      } catch (e) {
+        CrowdinLogger.printLog(e.toString());
+        _arb = null;
+        return;
+      }
     }
 
     if (!await _isConnectionTypeAllowed(_connectionType)) {

--- a/lib/src/crowdin.dart
+++ b/lib/src/crowdin.dart
@@ -50,8 +50,10 @@ class Crowdin {
 
   static bool get withRealTimeUpdates => _withRealTimeUpdates;
 
+  static Map<String, dynamic>? _manifest;
+
   /// contains the manifest if it has been fetched before
-  static Map<String, dynamic>? manifest;
+  static Map<String, dynamic>? get manifest => _manifest;
 
   @visibleForTesting
   static set withRealTimeUpdates(bool value) {
@@ -96,7 +98,7 @@ class Crowdin {
     var manifest = await _api.getManifest(distributionHash: _distributionHash);
 
     if (manifest != null) {
-      Crowdin.manifest = manifest;
+      _manifest = manifest;
       _distributionsMap = manifest['content'];
 
       /// fetch manifest file to check if new updates available

--- a/lib/src/crowdin.dart
+++ b/lib/src/crowdin.dart
@@ -50,6 +50,9 @@ class Crowdin {
 
   static bool get withRealTimeUpdates => _withRealTimeUpdates;
 
+  /// contains the manifest if it has been fetched before
+  static Map<String, dynamic>? manifest;
+
   @visibleForTesting
   static set withRealTimeUpdates(bool value) {
     _withRealTimeUpdates = value;
@@ -93,6 +96,7 @@ class Crowdin {
     var manifest = await _api.getManifest(distributionHash: _distributionHash);
 
     if (manifest != null) {
+      Crowdin.manifest = manifest;
       _distributionsMap = manifest['content'];
 
       /// fetch manifest file to check if new updates available

--- a/lib/src/crowdin.dart
+++ b/lib/src/crowdin.dart
@@ -124,7 +124,6 @@ class Crowdin {
     }
   }
 
-  @visibleForTesting
   static void checkManifestForLocale(Locale locale) {
     if (manifest == null) {
       throw CrowdinException(

--- a/lib/src/crowdin_mapper.dart
+++ b/lib/src/crowdin_mapper.dart
@@ -11,6 +11,16 @@ class CrowdinMapper {
         : locale;
   }
 
+  /// Maps a lanugage code to a [Locale] object.
+  /// Reference https://support.crowdin.com/developer/language-codes/
+  static Locale localeFromLanguageCode(String languageCode) {
+    final parts = languageCode.split('-');
+    final lang = parts.first;
+    final country = parts.length > 1 ? parts.last : null;
+    return mapLocale(
+        Locale.fromSubtags(languageCode: lang, countryCode: country));
+  }
+
   // _localesMap contains language codes that is different on Crowdin and supported by GlobalMaterialLocalizations class
   static const Map<String, String> _localesMap = {
     'hy': 'hy-AM', // Armenian

--- a/test/crowdin_manifest_test.dart
+++ b/test/crowdin_manifest_test.dart
@@ -150,12 +150,4 @@ void main() {
           throwsA(isA<CrowdinException>()));
     });
   });
-
-  group('Crowdin.loadTranslations', () {
-    test('should not throw if manifest not set', () async {
-      Crowdin.manifest = null;
-      expect(() async => await Crowdin.loadTranslations(const Locale('en')),
-          isA<void>());
-    });
-  });
 }

--- a/test/crowdin_manifest_test.dart
+++ b/test/crowdin_manifest_test.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:crowdin_sdk/src/crowdin.dart';
+import 'package:crowdin_sdk/src/exceptions/crowdin_exceptions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    var manifest = jsonDecode('''
+      {
+        "files": [
+          "/develop/lib/localization/locales/example_%locale_with_underscore%.arb"
+        ],
+        "languages": [
+          "zh-CN",
+          "nl",
+          "nl-BE",
+          "en",
+          "en-GB",
+          "fi",
+          "fr",
+          "de",
+          "it",
+          "ja",
+          "pt",
+          "ru",
+          "es",
+          "sv",
+          "tr"
+        ],
+        "language_mapping": {
+          "nl": {
+            "locale_with_underscore": "nl"
+          },
+          "fi": {
+            "locale_with_underscore": "fi"
+          },
+          "fr": {
+            "locale_with_underscore": "fr"
+          },
+          "de": {
+            "locale_with_underscore": "de"
+          },
+          "it": {
+            "locale_with_underscore": "it"
+          },
+          "ja": {
+            "locale_with_underscore": "ja"
+          },
+          "pt": {
+            "locale_with_underscore": "pt"
+          },
+          "ru": {
+            "locale_with_underscore": "ru"
+          },
+          "es": {
+            "locale_with_underscore": "es"
+          },
+          "sv": {
+            "locale_with_underscore": "sv"
+          },
+          "tr": {
+            "locale_with_underscore": "tr"
+          },
+          "zh-CN": {
+            "locale_with_underscore": "zh"
+          }
+        },
+        "custom_languages": [],
+        "timestamp": 1747301471,
+        "content": {
+          "zh-CN": [
+            "/content/develop/lib/localization/locales/example_zh.arb"
+          ],
+          "nl": [
+            "/content/develop/lib/localization/locales/example_nl.arb"
+          ],
+          "nl-BE": [
+            "/content/develop/lib/localization/locales/example_nl_BE.arb"
+          ],
+          "en": [
+            "/content/develop/lib/localization/locales/example_en_US.arb"
+          ],
+          "en-GB": [
+            "/content/develop/lib/localization/locales/example_en_GB.arb"
+          ],
+          "en-US": [
+            "/content/develop/lib/localization/locales/example_en_US.arb"
+          ],
+          "fi": [
+            "/content/develop/lib/localization/locales/example_fi.arb"
+          ],
+          "fr": [
+            "/content/develop/lib/localization/locales/example_fr.arb"
+          ],
+          "de": [
+            "/content/develop/lib/localization/locales/example_de.arb"
+          ],
+          "it": [
+            "/content/develop/lib/localization/locales/example_it.arb"
+          ],
+          "ja": [
+            "/content/develop/lib/localization/locales/example_ja.arb"
+          ],
+          "pt": [
+            "/content/develop/lib/localization/locales/example_pt.arb"
+          ],
+          "ru": [
+            "/content/develop/lib/localization/locales/example_ru.arb"
+          ],
+          "es": [
+            "/content/develop/lib/localization/locales/example_es.arb"
+          ],
+          "sv": [
+            "/content/develop/lib/localization/locales/example_sv.arb"
+          ],
+          "tr": [
+            "/content/develop/lib/localization/locales/example_tr.arb"
+          ]
+        },
+        "mapping": [
+          "/mapping/develop/lib/localization/locales/example_en_US.arb"
+        ]
+      }
+''');
+    Crowdin.manifest = manifest;
+  });
+
+  group('Crowdin.checkManifestForLocale', () {
+    test('should throw if locale is not supported according to manifest', () {
+      expect(
+        () => Crowdin.checkManifestForLocale(const Locale('xx')),
+        throwsA(isA<CrowdinException>()),
+      );
+    });
+    test('should not throw if locale is supported according to manifest', () {
+      expect(() => Crowdin.checkManifestForLocale(const Locale('es')),
+          isA<void>());
+    });
+    test(
+        'should succeed and fallback on language code only if locale with both language and country code is not found',
+        () {
+      expect(() => Crowdin.checkManifestForLocale(const Locale('en', 'US')),
+          isA<void>());
+    });
+    test('should throw if manifest not set', () {
+      Crowdin.manifest = null;
+      expect(() => Crowdin.checkManifestForLocale(const Locale('en')),
+          throwsA(isA<CrowdinException>()));
+    });
+  });
+
+  group('Crowdin.loadTranslations', () {
+    test('should not throw if manifest not set', () async {
+      Crowdin.manifest = null;
+      expect(() async => await Crowdin.loadTranslations(const Locale('en')),
+          isA<void>());
+    });
+  });
+}

--- a/test/crowdin_manifest_test.dart
+++ b/test/crowdin_manifest_test.dart
@@ -139,10 +139,10 @@ void main() {
           isA<void>());
     });
     test(
-        'should succeed and fallback on language code only if locale with both language and country code is not found',
+        'should throw if country variant of locale is not supported according to manifest',
         () {
       expect(() => Crowdin.checkManifestForLocale(const Locale('en', 'US')),
-          isA<void>());
+          throwsA(isA<CrowdinException>()));
     });
     test('should throw if manifest not set', () {
       Crowdin.manifest = null;

--- a/test/crowdin_mapper_test.dart
+++ b/test/crowdin_mapper_test.dart
@@ -3,15 +3,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('should return same locale when locale is not in map', () {
-    expect(CrowdinMapper.mapLocale(const Locale('en')), const Locale('en'));
+  group('CrowdinMapper.mapLocale', () {
+    test('should return same locale when locale is not in map', () {
+      expect(CrowdinMapper.mapLocale(const Locale('en')), const Locale('en'));
+    });
+
+    test('should map locale correctly when language tag is used', () {
+      expect(
+          CrowdinMapper.mapLocale(const Locale('hy')), const Locale('hy-AM'));
+    });
+
+    test('should return same locale when language tag is not in map', () {
+      expect(CrowdinMapper.mapLocale(const Locale('ja')), const Locale('ja'));
+    });
   });
 
-  test('should map locale correctly when language tag is used', () {
-    expect(CrowdinMapper.mapLocale(const Locale('hy')), const Locale('hy-AM'));
-  });
+  group('CrowdinMapper.localeFromLanguageCode', () {
+    test('should return correct Locale for language code with country', () {
+      expect(CrowdinMapper.localeFromLanguageCode('nl-BE'),
+          const Locale('nl', 'BE'));
+    });
 
-  test('should return same locale when language tag is not in map', () {
-    expect(CrowdinMapper.mapLocale(const Locale('ja')), const Locale('ja'));
+    test(
+        'should return Crowdin side locale correctly when language tag is used',
+        () {
+      expect(CrowdinMapper.localeFromLanguageCode('zh'), const Locale('zh-CN'));
+    });
+
+    test('should return correct Locale for language code without country', () {
+      expect(CrowdinMapper.localeFromLanguageCode('en'), const Locale('en'));
+    });
+
+    test('should return same locale when language code is not in map', () {
+      expect(CrowdinMapper.localeFromLanguageCode('xx-YY'),
+          const Locale('xx', 'YY'));
+    });
   });
 }


### PR DESCRIPTION
This PR makes the downloaded manifest (which happens during `init`) available under the static getter `Crowdin.manifest`. 
This way once can check if a certain language is supported before calling ` await Crowdin.loadTranslations`. Calling  `await Crowdin.loadTranslations` results in an exception which is caught within the package. The function also does not return anything. With the manifest publicly exposed the app code can first check if it makes sense to call `loadTranslations` with a certain locale. One want to avoid to download the manifest again because every requests counts for the request count. Because this package already downloads the manifest I opted to make it publicly available. 